### PR TITLE
pin `asdf` to newest patch version to fix dependency for newest `jsonschema` release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,12 +127,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [ acstools, ccdproc, costools, jwst, reftools, synphot, wfpc2tools ]
+        package: [ acstools, asdf, ccdproc, costools, jwst, reftools, synphot, wfpc2tools ]
         os: [ ubuntu-latest, macos-latest ]
         python: [ '3.8', '3.9', '3.10' ]
         include:
           - package: acstools
             dependencies: [ pytest-astropy-header, pytest-remotedata ]
+          - package: asdf
+            dependencies: [ 'astropy >=5.0.4', 'gwcs', 'pytest-doctestplus', 'pytest-remotedata', 'pytest-openfiles', 'psutil', 'lz4 >=0.10' ]
           - package: ccdproc
             dependencies: [ memory_profiler, pytest-astropy ]
           - package: costools
@@ -214,13 +216,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [ asdf, calcos, hstcal, stsynphot ]
+        package: [ calcos, hstcal, stsynphot ]
         os: [ ubuntu-latest, macos-latest ]
         python: [ '3.8', '3.9', '3.10' ]
         include:
-          - package: asdf
-            repository: asdf-format/asdf
-            extra: tests
           - package: calcos
             repository: spacetelescope/calcos
           #- package: drizzlepac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,10 +214,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [ calcos, hstcal, stsynphot ]
+        package: [ asdf, calcos, hstcal, stsynphot ]
         os: [ ubuntu-latest, macos-latest ]
         python: [ '3.8', '3.9', '3.10' ]
         include:
+          - package: asdf
+            repository: asdf-format/asdf
+            extra: tests
           - package: calcos
             repository: spacetelescope/calcos
           #- package: drizzlepac

--- a/stenv-dev.yml
+++ b/stenv-dev.yml
@@ -8,6 +8,7 @@ dependencies:
   - python==3.9
   - pip:
       - git+https://github.com/spacetelescope/acstools.git
+      - git+https://github.com/asdf-format/asdf.git
       - git+https://github.com/spacetelescope/calcos.git
       - git+https://github.com/spacetelescope/ccdproc.git
       - ci-watson

--- a/stenv-latest.yml
+++ b/stenv-latest.yml
@@ -8,6 +8,7 @@ dependencies:
   - python==3.9
   - pip:
       - acstools
+      - asdf>=2.12.1
       - calcos
       - ccdproc
       - ci-watson
@@ -19,7 +20,7 @@ dependencies:
       - h5py
       - ipython
       - jupyter
-      - jwst>=1.6.0
+      - jwst>=1.6.2
       - nictools
       - pysynphot
       - pytest

--- a/stenv-stable.yml
+++ b/stenv-stable.yml
@@ -8,6 +8,7 @@ dependencies:
   - python==3.9
   - pip:
       - acstools>=3.3.1,<3.4
+      - asdf>=2.12.1,<2.13
       - calcos>=3.4.3,<3.5
       - ccdproc>=2.3.1,<2.4
       - ci-watson


### PR DESCRIPTION
related to https://github.com/asdf-format/asdf/pull/1171; when `asdf 2.12.1` is released, this PR can be merged