### PR TITLE
remove `pysynphot` from environment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,10 +50,6 @@ jobs:
           - package: jwst
             test-extras: test
             crds-observatory: jwst
-          # - package: pysynphot
-          #   test-dependencies: >-
-          #     pytest
-          #     pytest-remotedata
           - package: reftools
             test-dependencies: test
           - package: synphot

--- a/environment.yaml
+++ b/environment.yaml
@@ -27,7 +27,6 @@ dependencies:
       - ginga
       - jwst
       - nictools
-      - pysynphot
       - reftools
       - stcal
       - stdatamodels


### PR DESCRIPTION
from @rizeladiaz:
> Pysynphot   is the engine of the HST ETC, so I would say that we need to have it available until we migrate all HST ETC to pandeia and we improve on the new Synphot documentation.