### PR TITLE
use mamba to build environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
       - uses: mamba-org/provision-with-micromamba@v13
         with:
           environment-name: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
-          environment-file: stenv-${{ env.CONSTRAINT }}.yml
+          environment-file: stenv/stenv-${{ env.CONSTRAINT }}.yml
           cache-env: true
           cache-downloads: true
       - run: echo "package_version=$(conda list | awk '$1 == "${{ matrix.package }}" {print $2}')" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,6 @@ jobs:
           environment-file: stenv-${{ env.CONSTRAINT }}.yml
           cache-env: true
           cache-downloads: true
-      - run: conda env export
       - run: pytest -n auto tests/test_import.py
   unit_tests:
     name: run `${{ matrix.package }}` unit tests in ${{ github.event.inputs.constraint }} Python ${{ matrix.python }} environment on ${{ matrix.os }}
@@ -116,7 +115,6 @@ jobs:
         if: matrix.extras != ''
       - run: ${{ join(matrix.commands, ' && ') }}
         if: matrix.commands != ''
-      - run: conda env export
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.env.CRDS_SERVER_URL != ''
         env:
@@ -203,7 +201,6 @@ jobs:
           ref: ${{ env.package_version }}
       - run: cd ${{ matrix.package }} && pip install ".[${{ join(matrix.extras, ',') }}]"
         if: matrix.extras != ''
-      - run: conda env export
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.env.CRDS_SERVER_URL != ''
         env:
@@ -268,7 +265,6 @@ jobs:
           environment-file: stenv-${{ env.CONSTRAINT }}.yml
           cache-env: true
           cache-downloads: true
-      - run: conda env export
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.env.CRDS_SERVER_URL != ''
         env:
@@ -325,13 +321,22 @@ jobs:
         id: version
         with:
           args: --pattern "(?P<base>\d+\.\d+\.\d+)"
-      - uses: mamba-org/provision-with-micromamba@v13
+      - run: echo "::set-output name=date::$(date +'%Y.%m.%d')"
+        id: date
+      - uses: actions/cache@v3
         with:
-          environment-name: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
+          path: |
+            ${{ env.HOME }}/conda_pkgs_dir
+            ${{ env.CONDA }}/envs/stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
+          key: conda-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}-${{ steps.date.outputs.date }}-${{ hashFiles(format('stenv-{0}.yml', env.CONSTRAINT)) }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
           environment-file: stenv-${{ env.CONSTRAINT }}.yml
-          cache-env: true
-          cache-downloads: true
-      - run: conda env export --no-builds > stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml
+          python-version: ${{ matrix.python }}.*
+          auto-update-conda: true
+          use-only-tar-bz2: true
+      - run: conda env export --no-build > stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml
       - run: |
           sed -i "/name:/d" stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml
           sed -i "/prefix:/d" stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,13 +43,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - run: |
-          echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
-          echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
+      - run: echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
         if: runner.os == 'Linux'
-      - run: |
-          echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
-          echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
+      - run: echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
         if: runner.os == 'MacOS'
       - run: sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" stenv-${{ env.CONSTRAINT }}.yml
         if: runner.os == 'Linux'
@@ -58,22 +54,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - run: echo "date=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
-        id: date
-      - uses: actions/cache@v3
-        id: cache
+      - uses: mamba-org/provision-with-micromamba@v13
         with:
-          path: |
-            ${{ env.HOME }}/conda_pkgs_dir
-            ${{ env.CONDA }}/envs/stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
-          key: conda-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}-${{ env.date }}-${{ hashFiles(format('stenv-{0}.yml', env.CONSTRAINT)) }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
+          environment-name: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
           environment-file: stenv-${{ env.CONSTRAINT }}.yml
-          python-version: ${{ matrix.python }}.*
-          auto-update-conda: true
-          use-only-tar-bz2: true
+          cache-env: true
+          cache-downloads: true
       - run: conda env export
       - run: pytest -n auto tests/test_import.py
   unit_tests:
@@ -109,13 +95,9 @@ jobs:
     steps:
       - run: echo "CONSTRAINT=$(if [ -z ${{ github.event.inputs.constraint }} ]; then echo latest; else echo ${{ github.event.inputs.constraint }}; fi)" >> $GITHUB_ENV
       - uses: actions/checkout@v3
-      - run: |
-          echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
-          echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
+      - run: echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
         if: runner.os == 'Linux'
-      - run: |
-          echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
-          echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
+      - run: echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
         if: runner.os == 'MacOS'
       - run: sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" stenv-${{ env.CONSTRAINT }}.yml
         if: runner.os == 'Linux'
@@ -124,21 +106,12 @@ jobs:
       - run: |
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
           echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
-      - run: echo "date=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
-        id: date
-      - uses: actions/cache@v3
+      - uses: mamba-org/provision-with-micromamba@v13
         with:
-          path: |
-            ${{ env.HOME }}/conda_pkgs_dir
-            ${{ env.CONDA }}/envs/stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
-          key: conda-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}-${{ env.date }}-${{ hashFiles(format('stenv-{0}.yml', env.CONSTRAINT)) }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
+          environment-name: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
           environment-file: stenv-${{ env.CONSTRAINT }}.yml
-          python-version: ${{ matrix.python }}.*
-          auto-update-conda: true
-          use-only-tar-bz2: true
+          cache-env: true
+          cache-downloads: true
       - run: pip install "${{ matrix.package }}[${{ join(matrix.extras, ',') }}]"
         if: matrix.extras != ''
       - run: ${{ join(matrix.commands, ' && ') }}
@@ -203,13 +176,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: stenv
-      - run: |
-          echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
-          echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
+      - run: echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
         if: runner.os == 'Linux'
-      - run: |
-          echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
-          echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
+      - run: echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
         if: runner.os == 'MacOS'
       - run: sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" stenv/stenv-${{ env.CONSTRAINT }}.yml
         if: runner.os == 'Linux'
@@ -218,21 +187,12 @@ jobs:
       - run: |
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
           echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
-      - run: echo "date=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
-        id: date
-      - uses: actions/cache@v3
+      - uses: mamba-org/provision-with-micromamba@v13
         with:
-          path: |
-            ${{ env.HOME }}/conda_pkgs_dir
-            ${{ env.CONDA }}/envs/stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
-          key: conda-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}-${{ env.date }}-${{ hashFiles(format('stenv-{0}.yml', env.CONSTRAINT)) }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
-          environment-file: stenv/stenv-${{ env.CONSTRAINT }}.yml
-          python-version: ${{ matrix.python }}.*
-          auto-update-conda: true
-          use-only-tar-bz2: true
+          environment-name: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
+          environment-file: stenv-${{ env.CONSTRAINT }}.yml
+          cache-env: true
+          cache-downloads: true
       - run: echo "package_version=$(conda list | awk '$1 == "${{ matrix.package }}" {print $2}')" >> $GITHUB_ENV
         # TODO: figure out a better way to use package version when checking out a Git ref
         if: env.CONSTRAINT != 'dev'
@@ -291,13 +251,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
-      - run: |
-          echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
-          echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
+      - run: echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
         if: runner.os == 'Linux'
-      - run: |
-          echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
-          echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
+      - run: echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
         if: runner.os == 'MacOS'
       - run: sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" stenv-${{ env.CONSTRAINT }}.yml
         if: runner.os == 'Linux'
@@ -306,21 +262,12 @@ jobs:
       - run: |
           echo "CRDS_PATH=${{ env.HOME }}/crds_cache" >> $GITHUB_ENV
           echo "PYSYN_CDBS=${{ env.HOME }}/trds" >> $GITHUB_ENV
-      - run: echo "date=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
-        id: date
-      - uses: actions/cache@v3
+      - uses: mamba-org/provision-with-micromamba@v13
         with:
-          path: |
-            ${{ env.HOME }}/conda_pkgs_dir
-            ${{ env.CONDA }}/envs/stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
-          key: conda-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}-${{ env.date }}-${{ hashFiles(format('stenv-{0}.yml', env.CONSTRAINT)) }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
+          environment-name: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
           environment-file: stenv-${{ env.CONSTRAINT }}.yml
-          python-version: ${{ matrix.python }}.*
-          auto-update-conda: true
-          use-only-tar-bz2: true
+          cache-env: true
+          cache-downloads: true
       - run: conda env export
       - run: echo "CRDS_CONTEXT=$(crds list --operational-context)" >> $GITHUB_ENV
         if: matrix.env.CRDS_SERVER_URL != ''
@@ -363,13 +310,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - run: |
-          echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
-          echo "CONDA=$(echo /usr/share/miniconda)" >> $GITHUB_ENV
+      - run: echo "HOME=$(echo /home/runner)" >> $GITHUB_ENV
         if: runner.os == 'Linux'
-      - run: |
-          echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
-          echo "CONDA=$(echo /usr/local/miniconda)" >> $GITHUB_ENV
+      - run: echo "HOME=$(echo /Users/runner)" >> $GITHUB_ENV
         if: runner.os == 'MacOS'
       - run: sed -i "s/python==3.9/python==${{ matrix.python }}.*/g" stenv-${{ env.CONSTRAINT }}.yml
         if: runner.os == 'Linux'
@@ -382,19 +325,12 @@ jobs:
         id: version
         with:
           args: --pattern "(?P<base>\d+\.\d+\.\d+)"
-      - uses: actions/cache@v3
+      - uses: mamba-org/provision-with-micromamba@v13
         with:
-          path: |
-            ${{ env.HOME }}/conda_pkgs_dir
-            ${{ env.CONDA }}/envs/stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
-          key: conda-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}-${{ env.date }}-${{ hashFiles(format('stenv-{0}.yml', env.CONSTRAINT)) }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
+          environment-name: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
           environment-file: stenv-${{ env.CONSTRAINT }}.yml
-          python-version: ${{ matrix.python }}.*
-          auto-update-conda: true
-          use-only-tar-bz2: true
+          cache-env: true
+          cache-downloads: true
       - run: conda env export --no-builds > stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml
       - run: |
           sed -i "/name:/d" stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,7 +327,9 @@ jobs:
         with:
           activate-environment: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
           python-version: ${{ matrix.python }}.*
-          use-mamba: true
+          mamba-version: '*'
+          channels: conda-forge,defaults
+          channel-priority: true
           use-only-tar-bz2: true
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -321,21 +321,21 @@ jobs:
         id: version
         with:
           args: --pattern "(?P<base>\d+\.\d+\.\d+)"
-      - run: echo "::set-output name=date::$(date +'%Y.%m.%d')"
+      - run: echo "::set-output name=date::$(date +'%a %b %d %Y')"
         id: date
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
+          python-version: ${{ matrix.python }}.*
+          use-mamba: true
+          use-only-tar-bz2: true
       - uses: actions/cache@v3
         with:
           path: |
             ${{ env.HOME }}/conda_pkgs_dir
             ${{ env.CONDA }}/envs/stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
-          key: conda-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}-${{ steps.date.outputs.date }}-${{ hashFiles(format('stenv-{0}.yml', env.CONSTRAINT)) }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
-          environment-file: stenv-${{ env.CONSTRAINT }}.yml
-          python-version: ${{ matrix.python }}.*
-          auto-update-conda: true
-          use-only-tar-bz2: true
+          key: "micromamba-env ${{ runner.os }} ${{ runner.arch }} ${{ steps.date.outputs.date }} file: ${{ hashFiles(format('stenv-{0}.yml', env.CONSTRAINT)) }}"
+      - run: mamba env update -n stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }} -f stenv-${{ env.CONSTRAINT }}.yml
       - run: conda env export --no-build > stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml
       - run: |
           sed -i "/name:/d" stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -321,6 +321,7 @@ jobs:
         id: version
         with:
           args: --pattern "(?P<base>\d+\.\d+\.\d+)"
+      # TODO: change following to `provision-with-micromamba` after https://github.com/mamba-org/mamba/issues/2008
       - run: echo "::set-output name=date::$(date +'%a %b %d %Y')"
         id: date
       - uses: conda-incubator/setup-miniconda@v2
@@ -336,9 +337,10 @@ jobs:
           path: |
             ${{ env.HOME }}/conda_pkgs_dir
             ${{ env.CONDA }}/envs/stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }}
-          key: "micromamba-env ${{ runner.os }} ${{ runner.arch }} ${{ steps.date.outputs.date }} file: ${{ hashFiles(format('stenv-{0}.yml', env.CONSTRAINT)) }}"
+          key: "mamba-env ${{ runner.os }}-${{ runner.arch }} ${{ steps.date.outputs.date }} file: ${{ hashFiles(format('stenv-{0}.yml', env.CONSTRAINT)) }}"
       - run: mamba env update -n stenv-${{ runner.os }}-py${{ matrix.python }}-${{ env.CONSTRAINT }} -f stenv-${{ env.CONSTRAINT }}.yml
       - run: conda env export --no-build > stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml
+      # TODO: change previous to `provision-with-micromamba` after https://github.com/mamba-org/mamba/issues/2008
       - run: |
           sed -i "/name:/d" stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml
           sed -i "/prefix:/d" stenv-${{ runner.os }}-py${{ matrix.python }}-${{ steps.version.outputs.version }}-${{ env.CONSTRAINT }}.yml


### PR DESCRIPTION
`micromamba` is a `conda` client rewritten as a single C++ application; this makes it **much** faster than using `miniconda`. Using it in place of `miniconda` seems to significantly speed up the environment creation and caching process in the CI: whereas `miniconda` took between 1.5 and 11 minutes to provision an environment, `micromamba` takes between 15 and 50 seconds.

The current issue is that `micromamba` appears to have an issue with `env export` in that it doesn't show `pip` packages; I've opened an issue here: https://github.com/mamba-org/mamba/issues/2008; in the meantime, I've kept the `export` step only to use `miniconda` to export the YAML files.