### PR TITLE
unhide TOC tree on start page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,16 +3,15 @@ Space Telescope Environment (``stenv``)
 
 ``stenv`` is a set of installable Conda environments maintained by the `Space Telescope Science Institute (STScI) <http://www.stsci.edu/>`_ in Baltimore, Maryland. These environments provide tools and utilities required to process and analyze data from the Hubble Space Telescope (HST), James Webb Space Telescope (JWST), and others.
 
-If you have issues with ``stenv``, please `create a new GitHub issue <https://github.com/spacetelescope/stenv/issues>`_ or contact one of the following help desks:
-
-* **HST Help Desk:** https://stsci.service-now.com/hst
-
-* **JWST Help Desk:** https://stsci.service-now.com/jwst
-
 .. toctree::
-   :hidden:
 
    getting_started.rst
    environments.rst
    astroconda.rst
    developer_notes.rst
+
+If you have issues with ``stenv``, please `create a new GitHub issue <https://github.com/spacetelescope/stenv/issues>`_ or contact one of the following help desks:
+
+* **HST Help Desk:** https://stsci.service-now.com/hst
+
+* **JWST Help Desk:** https://stsci.service-now.com/jwst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,6 +4,7 @@ Space Telescope Environment (``stenv``)
 ``stenv`` is a set of installable Conda environments maintained by the `Space Telescope Science Institute (STScI) <http://www.stsci.edu/>`_ in Baltimore, Maryland. These environments provide tools and utilities required to process and analyze data from the Hubble Space Telescope (HST), James Webb Space Telescope (JWST), and others.
 
 .. toctree::
+   :maxdepth: 1
 
    getting_started.rst
    environments.rst


### PR DESCRIPTION
This change unhides the table of contents on the main page of the documentation, as the navigation index is hidden by default on smaller screens

from email suggestion:
```
   hi Nadia,

   thanks very much!! That level of detail is indeed be sufficient. However 
   I had completely missed this because initially the "Getting started" 
   link was not appearing for me since the left-hand menu was not expanding 
   given my browser window width -- so I only saw the very simple page, see 
   attached screenshot.

   When I made my browser window wider, I now see the "Getting started" 
   link on the left, and when I click on that, indeed it has the level of 
   detail needed.

   However, this does reveal a problem with the "feature" on readthedocs 
   that a page won't auto-expand the left-hand menu unless it's wide 
   enough. So, some users might end up in the same place I was, since they 
   might not be aware of the auto-expand / missing menu issue, ie they 
   would just see the very simple page (then their next step would be to 
   email help).

   Might it be possible for you to edit the main page 
   "[stenv.readthedocs.io](http://stenv.readthedocs.io/)", to just place a simple, extra, separate, 
   one-line sentence (just above "If you have issues with..") that says 
   something like the following:

   Click "Getting Started" for the details on setting up and using stenv.

   (that way, we'd make it easier for users to find the getting started 
   link regardless of whatever happens for them with the left hand menu)

   thanks again,
   cheers,
   - Anton.
```