### PR TITLE
add reference to fallback instructions to use unconstrained environment file

### DIFF
--- a/docs/source/developer_notes.rst
+++ b/docs/source/developer_notes.rst
@@ -15,6 +15,12 @@ Developer Notes
 .. literalinclude:: ../../environment.yaml
    :language: yaml
 
+To build an environment from this unpinned environment definition, you may run the following:
+
+.. code-block:: shell
+
+    conda env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+
 .. _adding_a_package_to_stenv:
 
 Adding a package to ``stenv``

--- a/docs/source/developer_notes.rst
+++ b/docs/source/developer_notes.rst
@@ -3,7 +3,7 @@ Developer Notes
 
 ``stenv`` consists of several parts:
 
-#. a mostly unconstrained Conda environment definition YAML file :ref:`environment_yaml`
+#. an unpinned Conda environment definition YAML file :ref:`environment_yaml`
 #. a `GitHub Actions CI workflow <https://github.com/spacetelescope/stenv/actions/workflows/build.yaml>`_ that automatically builds and tests the environment on several platforms
 #. `regular GitHub releases <https://github.com/spacetelescope/stenv/releases>`_ with attached constrained Conda environment definition YAML files for every tested platform
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -3,8 +3,8 @@ Frequently Asked Questions
 
 .. _build_fails:
 
-`stenv` doesn't build on my system; what do I do?
-=================================================
+``stenv`` doesn't build on my system; what do I do?
+===================================================
 
 You can use the environment definition YAML file (:ref:`environment_yaml`) in the root of the repository:
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,11 +1,19 @@
 Frequently Asked Questions
 ##########################
 
-What if my platform isn't listed in released YAML files, or a released YAML file doesn't build on my system?
-============================================================================================================
+.. _build_fails:
 
-If the YAML files built for a release (see :ref:`choose_release`) do not include your platform, you can use the environment definition YAML file (:ref:`environment_yaml`) in the root of the repository.
-Note, however, that this environment has not been tested for all platforms.
+`stenv` doesn't build on my system; what do I do?
+=================================================
+
+You can use the environment definition YAML file (:ref:`environment_yaml`) in the root of the repository:
+
+.. code-block:: shell
+
+    conda env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+
+This environment is unpinned, meaning it may take some time to resolve dependency versions. 
+Additionally, the resulting package versions may not have been tested for your platform.
 
 Why isn't _____ package in ``stenv``?
 =====================================

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -49,9 +49,6 @@ from the ``Assets`` section that corresponds with your platform.
 .. warning::
     Building and testing environments on supported platforms may take several minutes; **if a release was just made recently, you may need to wait** for its `associated workflow job to finish <https://github.com/spacetelescope/stenv/actions/workflows/build.yaml>`_ before environment files are available.
 
-.. warning::
-    ``stenv`` is not currently built or tested on Apple Silicon ARM64 processors (``M1``, ``M1 Max``, ``M1 Ultra``, ``M2``); until infrastructure is set up to test and build on these platforms, users with these processors are encouraged to use the unconstrained environment definition :ref:`environment_yaml` file instead.
-
 Build environment
 -----------------
 
@@ -69,6 +66,10 @@ This example assumes that you chose an environment file for Mac OSX (``macOS``) 
     .. code-block:: shell
 
         conda env create --file https://github.com/spacetelescope/stenv/releases/download/2023.02.16/stenv-macOS-py3.9-2023.02.16.yaml --name stenv-py3.9-2023.02.16
+
+.. note::
+    If the build does not succeed on your system, please refer to :ref:`build_fails`
+    ``stenv`` is not currently built or tested on Apple Silicon ARM64 processors (``M1``, ``M1 Max``, ``M1 Ultra``, ``M2``)
 
 Activating an environment
 =========================

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -69,7 +69,10 @@ This example assumes that you chose an environment file for Mac OSX (``macOS``) 
 
 .. note::
     If the build does not succeed on your system, please refer to :ref:`build_fails`
-    ``stenv`` is not currently built or tested on Apple Silicon ARM64 processors (``M1``, ``M1 Max``, ``M1 Ultra``, ``M2``)
+
+.. note::
+    ``stenv`` is not currently pre-built or tested for Apple Silicon ARM64 processors (``M1``, ``M1 Max``, ``M1 Ultra``, ``M2``);
+    in the meantime, you can see `this issue <https://github.com/spacetelescope/stenv/issues/86#issuecomment-1444583090>`_  or resolve the environment yourself with :ref:`environment_yaml`
 
 Activating an environment
 =========================


### PR DESCRIPTION
these instructions should improve readability in the case where a user's `conda create` command fails; it adds a note and a link to the relevant FAQ question with instructions to use the `environment.yaml` file to resolve the environment from scratch.

docs built at https://stenv--91.org.readthedocs.build/en/91/