### PR TITLE
remove `PYSYN_CDBS` environment variable from testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,6 @@ defaults:
 
 env:
   CRDS_PATH: /tmp/crds_cache
-  PYSYN_CDBS: /tmp/trds
 
 jobs:
   build:


### PR DESCRIPTION
attempt to fix test failure in `stsynphot` tests
https://github.com/spacetelescope/stenv/actions/runs/4596647399/jobs/8168599877#step:11:21
```
E   astropy.utils.exceptions.AstropyUserWarning: Failed to load Vega spectrum from /tmp/trds/calspec/alpha_lyr_stis_010.fits; Functionality involving Vega will be cripped: FileNotFoundError(2, 'No such file or directory')
```