### PR TITLE
test ASDF from source to include vendorized jsonschema

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,14 +73,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [ acstools, asdf, ccdproc, costools, reftools, synphot, wfpc2tools ]
+        package: [ acstools, ccdproc, costools, reftools, synphot, wfpc2tools ]
         runs-on: [ ubuntu-latest, macos-latest ]
         python-version: [ '3.9', '3.10', '3.11' ]
         include:
           - package: acstools
             extras: [ test ]
-          - package: asdf
-            extras: [ tests ]
           - package: ccdproc
             extras: [ test ]
           - package: costools
@@ -134,10 +132,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [ calcos, hstcal, jwst ]
+        package: [ asdf, calcos, hstcal, jwst ]
         runs-on: [ ubuntu-latest, macos-latest ]
         python-version: [ '3.9', '3.10', '3.11' ]
         include:
+          - package: asdf
+            repository: asdf-format/asdf
+            extras: [ tests ]
           - package: calcos
             repository: spacetelescope/calcos
           #- package: crds


### PR DESCRIPTION
attempts to resolve the following issue when running `asdf` tests via `--pyargs`:
https://github.com/spacetelescope/stenv/actions/runs/6162954331/job/16725854445#step:8:76
```
E   AttributeError: 'Namespace' object has no attribute 'jsonschema'
```