### PR TITLE
drop Python 3.9 and add Python 3.12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
         with:
           name: ${{ steps.output.outputs.filename }}
           path: ${{ steps.output.outputs.filename }}
-      - if: (github.event_name == 'release' && github.event.action == 'published')
+      - if: (github.event_name == 'release' && github.event.action == 'released')
         uses: svenstaro/upload-release-action@v2
         with:
           file: ${{ steps.output.outputs.filename }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
     runs-on: ${{ matrix.runs-on }}
     name: build (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,13 +58,13 @@ jobs:
               CRDS_SERVER_URL: https://jwst-crds.stsci.edu
         exclude:
           - runs-on: macos-latest
-            python-version: '3.9'
+            python-version: '3.10'
           - runs-on: macos-latest
-            python-version: '3.10'
-          - runs-on: macos-14
-            python-version: '3.9'
+            python-version: '3.11'
           - runs-on: macos-14
             python-version: '3.10'
+          - runs-on: macos-14
+            python-version: '3.11'
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.package }} (Python ${{ matrix.python-version }}, tox ${{ matrix.default_factors }}${{ matrix.args != '' && ' -- ' || '' }}${{ matrix.args }}, ${{ matrix.runs-on }})
@@ -132,13 +132,13 @@ jobs:
           - package: wfpc2tools
         exclude:
           - runs-on: macos-latest
-            python-version: '3.9'
+            python-version: '3.10'
           - runs-on: macos-latest
-            python-version: '3.10'
-          - runs-on: macos-14
-            python-version: '3.9'
+            python-version: '3.11'
           - runs-on: macos-14
             python-version: '3.10'
+          - runs-on: macos-14
+            python-version: '3.11'
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.package }} (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})
     steps:
@@ -196,13 +196,13 @@ jobs:
           #   extras: [ test ]
         exclude:
           - runs-on: macos-latest
-            python-version: '3.9'
+            python-version: '3.10'
           - runs-on: macos-latest
-            python-version: '3.10'
-          - runs-on: macos-14
-            python-version: '3.9'
+            python-version: '3.11'
           - runs-on: macos-14
             python-version: '3.10'
+          - runs-on: macos-14
+            python-version: '3.11'
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.package }} (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})
@@ -272,13 +272,13 @@ jobs:
             repository: spacetelescope/crds
         exclude:
           - runs-on: macos-latest
-            python-version: '3.9'
+            python-version: '3.10'
           - runs-on: macos-latest
-            python-version: '3.10'
-          - runs-on: macos-14
-            python-version: '3.9'
+            python-version: '3.11'
           - runs-on: macos-14
             python-version: '3.10'
+          - runs-on: macos-14
+            python-version: '3.11'
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.package }} (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})
     steps:
@@ -342,13 +342,13 @@ jobs:
               jref: hst/references/hst/
         exclude:
           - runs-on: macos-latest
-            python-version: '3.9'
+            python-version: '3.10'
           - runs-on: macos-latest
-            python-version: '3.10'
-          - runs-on: macos-14
-            python-version: '3.9'
+            python-version: '3.11'
           - runs-on: macos-14
             python-version: '3.10'
+          - runs-on: macos-14
+            python-version: '3.11'
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.package }} (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         package: [ acstools, asdf, calcos, ccdproc, costools, synphot, jwst ]
         runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         include:
           - package: acstools
             repository: spacetelescope/acstools
@@ -123,7 +123,7 @@ jobs:
       matrix:
         package: [ reftools, wfpc2tools ]
         runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         include:
           #- package: pysynphot
           #  extras: [ test ]
@@ -178,7 +178,7 @@ jobs:
       matrix:
         package: [ hstcal ]
         runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         include:
           #- package: drizzlepac
           #  repository: spacetelescope/drizzlepac
@@ -266,7 +266,7 @@ jobs:
       matrix:
         package: [ crds ]
         runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         include:
           - package: crds
             repository: spacetelescope/crds
@@ -328,7 +328,7 @@ jobs:
       matrix:
         package: [ calcos, drizzlepac ]
         runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         include:
           - package: calcos
             run: calcos la8n01qkq_rawtag_a.fits

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,7 +15,7 @@ dependencies:
   - numpy
   - pip
   - pytables
-  - python<3.12
+  - python>=3.10
   - pytest
   - pytest-xdist
   - scipy


### PR DESCRIPTION
currently, the environment will not build with Python 3.12 because of `scipy`:
https://github.com/spacetelescope/stenv/actions/runs/7672163531/job/20912084061#step:3:992
```
../meson.build:85:2: ERROR: Problem encountered: Your Python version is too new. SciPy 1.9 supports Python 3.8-3.11; if you are trying to build from source for the most recent SciPy version you may hit this error as well. Please build from the `main` branch on GitHub instead.
```

I'll keep this PR in draft until that changes