### PR TITLE
add instructions on how to run `conda init` and also include tab option for `mamba` commands

### DIFF
--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -13,3 +13,4 @@ dependencies:
     - sphinx-rtd-theme
     - pip:
         - stsci-rtd-theme
+        - sphinx-inline-tabs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ intersphinx_mapping = {
 
 extensions = [
     'sphinx.ext.intersphinx',
+    'sphinx_inline_tabs',
 ]
 
 templates_path = ['_templates']

--- a/docs/source/developer_notes.rst
+++ b/docs/source/developer_notes.rst
@@ -17,16 +17,24 @@ Developer Notes
 
 To build an environment from this unpinned environment definition, you may run the following:
 
-.. code-block:: shell
+.. tab:: conda
 
-    conda env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+    .. code-block:: shell
+
+        conda create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+
+.. tab:: mamba
+
+    .. code-block:: shell
+
+        mamba create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
 
 .. _adding_a_package_to_stenv:
 
 Adding a package to ``stenv``
 =============================
 
-To request that a new package be added to ``stenv``, or to add a package yourself, please `create a new issue in the repository <https://github.com/spacetelescope/stenv/issues/new?assignees=&labels=add+package&template=package_addition_request.md&title=add+%60%3Cpackage%3E%60+to+environment>`_.
+To request that a new package be added to ``stenv``, please `create a new issue in the repository <https://github.com/spacetelescope/stenv/issues/new?assignees=&labels=add+package&template=package_addition_request.md&title=add+%60%3Cpackage%3E%60+to+environment>`_.
 
 .. image:: ./images/add_package_issue_template.png
     :alt: issue template for adding a package

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -8,9 +8,17 @@ Frequently Asked Questions
 
 You can use the environment definition YAML file (:ref:`environment_yaml`) in the root of the repository:
 
-.. code-block:: shell
+.. tab:: conda
 
-    conda env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+    .. code-block:: shell
+
+        conda create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+
+.. tab:: mamba
+
+    .. code-block:: shell
+
+        mamba create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
 
 This environment is unpinned, meaning it may take some time to resolve dependency versions. 
 Additionally, the resulting package versions may not have been tested for your platform.
@@ -32,12 +40,21 @@ some packages are not supported and / or deprecated, and some are deemed too nic
 
 To install a package in your local environment, you can use ``pip install`` while the environment is activated:
 
-.. code-block:: shell
+.. tab:: conda
 
-    conda activate stenv
-    pip install <package_name>
+    .. code-block:: shell
 
-To request that a new package be added to ``stenv``'s base environment (:ref:`environment_yaml`) for all users, or to add a package yourself, see :ref:`adding_a_package_to_stenv`.
+        conda activate stenv
+        pip install <package_name>
+
+.. tab:: mamba
+
+    .. code-block:: shell
+
+        mamba activate stenv
+        pip install <package_name>
+
+To request that a new package be added to ``stenv`` (:ref:`environment_yaml`) for all users, see :ref:`adding_a_package_to_stenv`.
 
 What about Astroconda?
 ======================

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -40,8 +40,8 @@ well as hundreds of useful tools, libraries, and utilities by default.
     will notice a speedup if they substitute ``mamba`` for ``conda`` where it appears in commands.
 
 .. important::
-    Remember to run ``conda init`` when installing. This is required in order to ``activate`` and 
-    ``deactivate`` environments.
+    Remember to run ``conda init`` when installing. This is required in order to set up your shell to 
+    ``activate`` and ``deactivate`` environments.
 
     .. tab:: conda
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -5,8 +5,12 @@ Conda Basics
 ============
 
 ``stenv`` defines a Conda environment, which is a set of packages installed together at specific versions.
-A Conda environment is designed to be isolated from system packages, and can be **activated** to switch the current context (PATH, environment variables, available binaries, Python installation, etc.) to an isolated instance that is separate from the system. (This is similar to using ``source bin/activate``, if you are familiar with Python virtualenvs.)
-This has the advantage of allowing several separate installations of Python packages and other tools without cluttering the system installation, allowing switching between use cases or package contexts at will.
+A Conda environment is designed to be isolated from system packages, and can be **activated** to switch the 
+current context (PATH, environment variables, available binaries, Python installation, etc.) to an isolated 
+instance that is separate from the system. (This is similar to using ``source bin/activate``, if you are 
+familiar with Python virtualenvs). This has the advantage of allowing several separate installations of 
+Python packages and other tools without cluttering the system installation, allowing switching between use 
+cases or package contexts at will.
 
 Installation
 ============
@@ -16,13 +20,40 @@ Installation
 Install Conda
 -------------
 
-A Conda distribution provides the ``conda`` command, which lets you create, manage, and activate new environments. Try running the ``conda`` command in your terminal. If you get ``conda: command not found`` (or similar), you will need to install a conda distribution. If you already have a ``conda`` command in your terminal, you can skip to the next step.
+A Conda distribution provides the ``conda`` command, which lets you create, manage, and activate new 
+environments. Try running the ``conda`` command in your terminal. If you get ``conda: command not found`` 
+(or similar), you will need to install a conda distribution. If you already have a ``conda`` command in 
+your terminal, you can skip to the next step.
 
-The easiest option is to install `Miniconda <https://docs.conda.io/projects/miniconda/en/latest/miniconda-install.html>`_, which is full-featured but installs a minimal set of default packages initially. We will install more packages later on.
+The easiest option is to install 
+`Miniconda <https://docs.conda.io/projects/miniconda/en/latest/miniconda-install.html>`_, which is 
+full-featured but installs a minimal set of default packages initially. We will install more packages later 
+on.
 
-Alternatives include `Miniforge <https://github.com/conda-forge/miniforge#miniforge3>`_, which includes the ``mamba`` command (a much faster replacement for ``conda`` with all the same functionality) and `Anaconda <https://www.anaconda.com/distribution/>`_ which provides a full-featured base environment as well as hundreds of useful tools, libraries, and utilities by default.
+Alternatives include `Miniforge <https://github.com/conda-forge/miniforge#miniforge3>`_, which includes the 
+``mamba`` command (a much faster drop-in replacement for ``conda`` with all the same functionality) and 
+`Anaconda <https://www.anaconda.com/distribution/>`_ which provides a full-featured base environment as 
+well as hundreds of useful tools, libraries, and utilities by default.
 
-The below instructions will work for any of the distributions, though Miniforge users will notice a speedup if they substitute ``mamba`` for ``conda`` when it appears in commands.
+.. note::
+    The below instructions will work for any of the distributions, though users with ``mamba`` installed 
+    will notice a speedup if they substitute ``mamba`` for ``conda`` where it appears in commands.
+
+.. important::
+    Remember to run ``conda init`` when installing. This is required in order to ``activate`` and 
+    ``deactivate`` environments.
+
+    .. tab:: conda
+
+        .. code-block:: shell
+
+            conda init
+
+    .. tab:: mamba
+
+        .. code-block:: shell
+
+            mamba init
 
 .. _choose_release:
 
@@ -30,79 +61,160 @@ Choose an ``stenv`` release
 ---------------------------
 
 Now that you have a Conda installation, you should choose a release of ``stenv`` from the
-`Releases page <https://github.com/spacetelescope/stenv/releases>`_ and choose the environment definition file
-from the ``Assets`` section that corresponds with your platform.
+`Releases page <https://github.com/spacetelescope/stenv/releases>`_ and choose the environment definition 
+file from the ``Assets`` section that corresponds with your platform.
 
 .. image:: ./images/release_example.png
     :alt: example of a release page, showing output files
     :target: https://github.com/spacetelescope/stenv/releases
 
-Every release is available for several combinations of operating system and Python version. The name of the release file indicates which is which. For example, a release of stenv for Python 3.11 on Linux will be named something like ``stenv-Linux-X64-py3.11-YYYY.MM.DD.yaml`` where ``YYYY.MM.DD`` is the date of the release. Unless you have particular requirements, you should choose the highest-numbered Python version available. (Note that version numbers aren't real numbers, and a hypothetical Python 3.20 would be newer than Python 3.2.)
-
-Having chosen which asset to download, right-click (or control-click on macOS) on the link name and choose "Copy Link" or "Copy Link Address". Now, open a terminal window.
+Every release is available for several combinations of operating system and Python version. 
+The name of the release file indicates which is which. For example, a release of stenv for Python ``3.11`` 
+on Linux will be named something like ``stenv-Linux-X64-py3.11-YYYY.MM.DD.yaml`` (where ``YYYY.MM.DD`` 
+is the date of the release). Unless you have particular requirements, you should choose the 
+newest (highest-numbered) Python version available. 
 
 .. note::
-    Every conda environment has a name. If you include the version numbers in the name, it will be easy to keep track of which version of stenv you have. So, you may want to replace ``stenv`` in the following example with ``stenv-py3.11-2023.01.01`` (changed as needed to match the version you downloaded).
+    Version numbers aren't real numbers; a hypothetical Python ``3.20`` would be newer than Python ``3.2``.
 
-**Short version:** In the terminal you have opened, you can create a conda environment by typing the command ``conda env create --name stenv --file``, a space, and then pasting the URL you copied in the last step. Hit enter to execute, and be prepared to wait a little while.
+.. warning::
+    **Can't find the release you need?** Building and testing environments on supported platforms may take 
+    several minutes; for new releases, you may need to wait for the 
+    `associated workflow job <https://github.com/spacetelescope/stenv/actions/workflows/build.yaml>`_ to
+    finish before environment files are available.
 
-**Detailed version:**
+.. note::
+    Every Conda environment has a name, specified by the ``--name`` or ``-n`` option. If you include the 
+    version numbers in the name, it will be easier to keep track of which version of ``stenv`` you have. 
+    Therefore, I recommend using a more descriptive name than ``stenv`` for your environment; for example, 
+    use something like ``stenv-py3.11-2023.01.01`` (changed as needed to match the version you chose).
 
-1. Download the file from the link in the Releases page
-2. In a terminal, navigate to the folder where you saved the file
-3. Run ``conda env create --name stenv --file stenv-XXXX`` where ``stenv-XXXX`` is replaced by the name of the file you downloaded
-4. Wait for the command to finish
+.. tab:: create environment from URL
+
+    Right-click (or control-click on macOS) on the link to the release file and choose ``Copy Link`` (or 
+    ``Copy Link Address``). Then, run the following command in a terminal, replacing ``<URL>`` with the URL you copied in the previous 
+    step:
+
+    .. tab:: conda
+
+        .. code-block:: shell
+
+            conda create --name stenv --file <URL>
+
+    .. tab:: mamba
+
+        .. code-block:: shell
+
+            mamba create --name stenv --file <URL>
+
+.. tab:: create environment from downloaded file
+
+    Download the release file you chose. Then, run the following command in a terminal, replacing 
+    ``~/Downloads/stenv-pyXX-YY.MM.DD.yaml`` with the path to the file you downloaded:
+
+    .. tab:: conda
+
+        .. code-block:: shell
+
+            conda create --name stenv --file ~/Downloads/stenv-pyXX-YY.MM.DD.yaml
+
+    .. tab:: mamba
+
+        .. code-block:: shell
+
+            mamba create --name stenv --file ~/Downloads/stenv-pyXX-YY.MM.DD.yaml
+
 
 .. note::
     If the build does not succeed on your system, please refer to :ref:`build_fails`
 
-.. warning::
-    **Can't find the release you need?** Building and testing environments on supported platforms may take several minutes; for new releases, you may need to wait for the `associated workflow job to finish <https://github.com/spacetelescope/stenv/actions/workflows/build.yaml>`_ before environment files are available.
-
 Activating an environment
 =========================
 
-Environments let you install packages while isolating them from the rest of your system, and even each other. Even though we just built an environment, we will not be able to import the new packages yet::
+Environments let you install packages while isolating them from the rest of your system, and even each 
+other. Even though we just created an environment, we will not be able to import the new packages yet:
+
+.. code-block:: shell
 
     $ python -c 'import jwst; print("ok")'
     Traceback (most recent call last):
       File "<string>", line 1, in <module>
     ModuleNotFoundError: No module named 'jwst'
 
-In order to access the packages in ``stenv``, you must activate the ``stenv`` environment: 
+In order to access the packages in ``stenv``, you must first ``activate`` the environment you just created: 
+
+.. important::
+    If you chose another name when creating the environment, use that here instead.
+
+.. tab:: conda
+
+    .. code-block:: shell
+
+        conda activate stenv
+
+.. tab:: mamba
+
+    .. code-block:: shell
+
+        mamba activate stenv
+
+Activating a Conda environment changes which Python interpreter and packages are in use for that session 
+(i.e. terminal window). Now, if you try to ``import jwst``:
 
 .. code-block:: shell
-
-    conda activate stenv
-
-(If you chose another name when creating the environment, use that here instead.)
-
-Activating a Conda environment changes which Python interpreter and packages are in use for that session (i.e. terminal window). Now, if you try to ``import jwst``::
 
     (stenv) $ python -c 'import jwst; print("ok")'
 
-Every time you open a new terminal window, you will need to activate the environment with ``conda activate <name>`` before you can use stenv software.
-
-.. code-block:: shell
-
-    conda activate stenv
+Every time you open a new terminal window, you will need to activate the environment before you can use 
+``stenv`` software.
 
 .. note::
-    You can show installed packages available within a Conda environment with ``conda list``.
+    You can show installed packages available within a Conda environment with ``conda list``:
 
-To deactivate an environment and return your shell to normal, run ``conda deactivate``:
+    .. tab:: conda
 
-.. code-block:: shell
+        .. code-block:: shell
 
-    conda deactivate
+            conda list
 
-(You can also just close the terminal window.)
+    .. tab:: mamba
+
+        .. code-block:: shell
+
+            mamba list
+
+To ``deactivate`` an environment and return your shell to normal, close your terminal window or run 
+``conda deactivate``:
+
+.. tab:: conda
+
+    .. code-block:: shell
+
+        conda deactivate
+
+.. tab:: mamba
+
+    .. code-block:: shell
+
+        mamba deactivate
 
 Deleting an environment
 =======================
 
-To delete an environment with all of its packages, run ``conda env remove -n <name>``:
+To delete an environment with all of its packages, run ``conda env remove --name <name>``:
 
-.. code-block:: shell
+.. important::
+    If you chose another name when creating the environment, use that here instead.
 
-    conda env remove -n stenv
+.. tab:: conda
+
+    .. code-block:: shell
+
+        conda env remove --name stenv
+
+.. tab:: mamba
+
+    .. code-block:: shell
+
+        mamba env remove --name stenv
+


### PR DESCRIPTION
add explicit instructions to run `conda init` when installing `conda` (in response to https://stsci.service-now.com/nav_to.do?uri=incident.do%3Fsys_id=a0df4b2d47ee71d0289c4f32736d438f%26sysparm_stack=incident_list.do%3Fsysparm_query=active=true)