### PR TITLE
fix create examples to include `env`

### DIFF
--- a/docs/source/developer_notes.rst
+++ b/docs/source/developer_notes.rst
@@ -21,13 +21,13 @@ To build an environment from this unpinned environment definition, you may run t
 
     .. code-block:: shell
 
-        conda create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+        conda env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
 
 .. tab:: mamba
 
     .. code-block:: shell
 
-        mamba create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+        mamba env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
 
 .. _adding_a_package_to_stenv:
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -12,13 +12,13 @@ You can use the environment definition YAML file (:ref:`environment_yaml`) in th
 
     .. code-block:: shell
 
-        conda create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+        conda env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
 
 .. tab:: mamba
 
     .. code-block:: shell
 
-        mamba create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+        mamba env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
 
 This environment is unpinned, meaning it may take some time to resolve dependency versions. 
 Additionally, the resulting package versions may not have been tested for your platform.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -99,13 +99,13 @@ newest (highest-numbered) Python version available.
 
         .. code-block:: shell
 
-            conda create --name stenv --file <URL>
+            conda env create --name stenv --file <URL>
 
     .. tab:: mamba
 
         .. code-block:: shell
 
-            mamba create --name stenv --file <URL>
+            mamba env create --name stenv --file <URL>
 
 .. tab:: create environment from downloaded file
 
@@ -116,13 +116,13 @@ newest (highest-numbered) Python version available.
 
         .. code-block:: shell
 
-            conda create --name stenv --file ~/Downloads/stenv-pyXX-YY.MM.DD.yaml
+            conda env create --name stenv --file ~/Downloads/stenv-pyXX-YY.MM.DD.yaml
 
     .. tab:: mamba
 
         .. code-block:: shell
 
-            mamba create --name stenv --file ~/Downloads/stenv-pyXX-YY.MM.DD.yaml
+            mamba env create --name stenv --file ~/Downloads/stenv-pyXX-YY.MM.DD.yaml
 
 
 .. note::


### PR DESCRIPTION
```
conda create -n stenv -f
```
->
```
conda env create -n stenv -f
```