### PR TITLE
run build workflow daily

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,8 @@
 name: build
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   workflow_call:
     inputs:
       export:
@@ -80,7 +82,7 @@ jobs:
         with:
           args: --pattern "(?P<base>\d+\.\d+\.\d+)"
   export:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event_name == 'release' || inputs.export == 'true'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'release' || inputs.export == 'true'
     needs: [ build, version, date ]
     strategy:
       fail-fast: false


### PR DESCRIPTION
this will keep an artifact record of environments, and also keep the cache updated