### PR TITLE
add `wheel` to environment for building wheels

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -21,6 +21,7 @@ dependencies:
   - scipy
   - scikit-image
   - sphinx
+  - wheel
   - pip:
       - acstools
       - asdf


### PR DESCRIPTION
in an attempt to diagnose the wheel building errors in #133 
```
Building wheels for collected packages: astroscrappy, calcos, reftools, stregion, stsci-image, stsci-stimage
  Building wheel for astroscrappy (pyproject.toml): started
  Building wheel for astroscrappy (pyproject.toml): finished with status 'error'
  Building wheel for calcos (pyproject.toml): started
  Building wheel for calcos (pyproject.toml): finished with status 'error'
  Building wheel for reftools (pyproject.toml): started
  Building wheel for reftools (pyproject.toml): finished with status 'error'
  Building wheel for stregion (pyproject.toml): started
  Building wheel for stregion (pyproject.toml): finished with status 'error'
  Building wheel for stsci-image (pyproject.toml): started
  Building wheel for stsci-image (pyproject.toml): finished with status 'error'
  Building wheel for stsci-stimage (pyproject.toml): started
  Building wheel for stsci-stimage (pyproject.toml): finished with status 'error'
Failed to build astroscrappy calcos reftools stregion stsci-image stsci-stimage
```
This PR adds `wheel` to the base environment so as to facilitate building wheels on WSL