### PR TITLE
use current date in filename

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,23 +38,8 @@ jobs:
         shell: bash
     outputs:
       date: ${{ steps.date.outputs.date }}
-  version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - uses: mtkennerly/dunamai-action@v1
-        id: version
-        with:
-          args: --pattern "(?P<base>\d+\.\d+\.\d+)"
   build:
-    needs: [ date, version ]
+    needs: [ date ]
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +64,7 @@ jobs:
           generate-run-shell: true
       - run: conda env export --no-build | grep -v "name:" | grep -v "prefix:"
       - run: pytest -n auto tests/test_import.py
-      - run: echo "filename=stenv-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ needs.version.outputs.version }}.yaml" >> $GITHUB_OUTPUT
+      - run: echo "filename=stenv-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ needs.date.outputs.date }}.yaml" >> $GITHUB_OUTPUT
         id: output
       - run: conda env export --no-build | grep -v "name:" | grep -v "prefix:" > ${{ steps.output.outputs.filename }}
       - run: cat ${{ steps.output.outputs.filename }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
   date:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+      - run: echo "date=$(date +%Y.%m.%d)" >> $GITHUB_OUTPUT
         id: date        
         shell: bash
     outputs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,12 +11,6 @@ on:
       date:
         value: ${{ jobs.date.outputs.date }}
   workflow_dispatch:
-    inputs:
-      upload_to_release:
-        description: upload exported files to a release of the current tag
-        required: false
-        type: boolean
-        default: false
   push:
   release:
     types:


### PR DESCRIPTION
using the `version` never really made much sense, especially since the updates to environment dependencies are disassociated from the Git ref