### PR TITLE
change matrix and use `macos-13` for Intel hardware

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
+        # the macOS 13 runner is on Intel hardware
+        runs-on: [ ubuntu-latest, macos-13, macos-latest ]
         python-version: [ '3.10', '3.11', '3.12' ]
     runs-on: ${{ matrix.runs-on }}
     name: build (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,8 @@ jobs:
     strategy:
       matrix:
         package: [ acstools, asdf, calcos, ccdproc, costools, synphot, jwst ]
-        runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
+        # the macOS 13 runner is on Intel hardware
+        runs-on: [ ubuntu-latest, macos-13, macos-latest ]
         python-version: [ '3.10', '3.11', '3.12' ]
         include:
           - package: acstools
@@ -57,13 +58,13 @@ jobs:
             env:
               CRDS_SERVER_URL: https://jwst-crds.stsci.edu
         exclude:
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: '3.10'
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: '3.11'
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python-version: '3.10'
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python-version: '3.11'
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
@@ -122,7 +123,8 @@ jobs:
       fail-fast: false
       matrix:
         package: [ reftools, wfpc2tools ]
-        runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
+        # the macOS 13 runner is on Intel hardware
+        runs-on: [ ubuntu-latest, macos-13, macos-latest ]
         python-version: [ '3.10', '3.11', '3.12' ]
         include:
           #- package: pysynphot
@@ -131,13 +133,13 @@ jobs:
             extras: [ test ]
           - package: wfpc2tools
         exclude:
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: '3.10'
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: '3.11'
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python-version: '3.10'
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python-version: '3.11'
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.package }} (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})
@@ -177,7 +179,8 @@ jobs:
     strategy:
       matrix:
         package: [ hstcal ]
-        runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
+        # the macOS 13 runner is on Intel hardware
+        runs-on: [ ubuntu-latest, macos-13, macos-latest ]
         python-version: [ '3.10', '3.11', '3.12' ]
         include:
           #- package: drizzlepac
@@ -195,13 +198,13 @@ jobs:
           #   repository: spacetelescope/stsynphot_refactor
           #   extras: [ test ]
         exclude:
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: '3.10'
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: '3.11'
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python-version: '3.10'
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python-version: '3.11'
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
@@ -265,19 +268,20 @@ jobs:
       fail-fast: false
       matrix:
         package: [ crds ]
-        runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
+        # the macOS 13 runner is on Intel hardware
+        runs-on: [ ubuntu-latest, macos-13, macos-latest ]
         python-version: [ '3.10', '3.11', '3.12' ]
         include:
           - package: crds
             repository: spacetelescope/crds
         exclude:
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: '3.10'
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: '3.11'
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python-version: '3.10'
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python-version: '3.11'
     runs-on: ${{ matrix.runs-on }}
     name: ${{ matrix.package }} (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})
@@ -327,7 +331,8 @@ jobs:
     strategy:
       matrix:
         package: [ calcos, drizzlepac ]
-        runs-on: [ ubuntu-latest, macos-latest, macos-14 ]
+        # the macOS 13 runner is on Intel hardware
+        runs-on: [ ubuntu-latest, macos-13, macos-latest ]
         python-version: [ '3.10', '3.11', '3.12' ]
         include:
           - package: calcos
@@ -341,13 +346,13 @@ jobs:
               CRDS_SERVER_URL: https://hst-crds.stsci.edu
               jref: hst/references/hst/
         exclude:
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: '3.10'
-          - runs-on: macos-latest
+          - runs-on: macos-13
             python-version: '3.11'
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python-version: '3.10'
-          - runs-on: macos-14
+          - runs-on: macos-latest
             python-version: '3.11'
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
it appears that `macos-latest`, having previously pointed to an Intel-based X86_64 macOS runner (`macos-13`), now points to an M1 AMR64 macOS runner (`macos-14`). As we still need to build and deliver `stenv` for Intel hardware, I have updated the workflows matrices to use `macos-13` and `macos-latest`