### PR TITLE
update docs to indicate that `micromamba` and `mamba` are recommended over `conda`

### DIFF
--- a/docs/source/developer_notes.rst
+++ b/docs/source/developer_notes.rst
@@ -15,7 +15,14 @@ Developer Notes
 .. literalinclude:: ../../environment.yaml
    :language: yaml
 
-To build an environment from this unpinned environment definition, you may run the following:
+To build an environment from this unpinned environment definition, run the following:
+
+.. tab:: micromamba
+
+    .. code-block:: shell
+
+        curl -L https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml -o ~/Downloads/stenv.yaml
+        micromamba env create --name stenv --file ~/Downloads/stenv.yaml
 
 .. tab:: mamba
 
@@ -28,13 +35,6 @@ To build an environment from this unpinned environment definition, you may run t
     .. code-block:: shell
 
         conda env create --name stenv --file https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
-
-.. tab:: micromamba
-
-    .. code-block:: shell
-
-        curl -L https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml -o ~/Downloads/stenv.yaml
-        micromamba env create --name stenv --file ~/Downloads/stenv.yaml
 
 .. _adding_a_package_to_stenv:
 

--- a/docs/source/developer_notes.rst
+++ b/docs/source/developer_notes.rst
@@ -17,17 +17,24 @@ Developer Notes
 
 To build an environment from this unpinned environment definition, you may run the following:
 
-.. tab:: conda
-
-    .. code-block:: shell
-
-        conda env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
-
 .. tab:: mamba
 
     .. code-block:: shell
 
-        mamba env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+        mamba env create --name stenv --file https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+
+.. tab:: conda
+
+    .. code-block:: shell
+
+        conda env create --name stenv --file https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+
+.. tab:: micromamba
+
+    .. code-block:: shell
+
+        curl -L https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml -o ~/Downloads/stenv.yaml
+        micromamba env create --name stenv --file ~/Downloads/stenv.yaml
 
 .. _adding_a_package_to_stenv:
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -8,17 +8,24 @@ Frequently Asked Questions
 
 You can use the environment definition YAML file (:ref:`environment_yaml`) in the root of the repository:
 
-.. tab:: conda
-
-    .. code-block:: shell
-
-        conda env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
-
 .. tab:: mamba
 
     .. code-block:: shell
 
-        mamba env create -n stenv -f https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+        mamba env create --name stenv --file https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+
+.. tab:: conda
+
+    .. code-block:: shell
+
+        conda env create --name stenv --file https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
+
+.. tab:: micromamba
+
+    .. code-block:: shell
+
+        curl -L https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml -o ~/Downloads/stenv.yaml
+        micromamba env create --name stenv --file ~/Downloads/stenv.yaml 
 
 This environment is unpinned, meaning it may take some time to resolve dependency versions. 
 Additionally, the resulting package versions may not have been tested for your platform.
@@ -35,6 +42,13 @@ some packages are not supported and / or deprecated, and some are deemed too nic
 
 To install a package in your local environment, you can use ``pip install`` while the environment is activated:
 
+.. tab:: mamba
+
+    .. code-block:: shell
+
+        mamba activate stenv
+        pip install <package_name>
+
 .. tab:: conda
 
     .. code-block:: shell
@@ -42,11 +56,11 @@ To install a package in your local environment, you can use ``pip install`` whil
         conda activate stenv
         pip install <package_name>
 
-.. tab:: mamba
+.. tab:: micromamba
 
     .. code-block:: shell
 
-        mamba activate stenv
+        micromamba activate stenv
         pip install <package_name>
 
 To request that a new package be added to ``stenv`` (:ref:`environment_yaml`) for all users, see :ref:`adding_a_package_to_stenv`.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -8,6 +8,13 @@ Frequently Asked Questions
 
 You can use the environment definition YAML file (:ref:`environment_yaml`) in the root of the repository:
 
+.. tab:: micromamba
+
+    .. code-block:: shell
+
+        curl -L https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml -o ~/Downloads/stenv.yaml
+        micromamba env create --name stenv --file ~/Downloads/stenv.yaml 
+
 .. tab:: mamba
 
     .. code-block:: shell
@@ -19,13 +26,6 @@ You can use the environment definition YAML file (:ref:`environment_yaml`) in th
     .. code-block:: shell
 
         conda env create --name stenv --file https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml 
-
-.. tab:: micromamba
-
-    .. code-block:: shell
-
-        curl -L https://raw.githubusercontent.com/spacetelescope/stenv/main/environment.yaml -o ~/Downloads/stenv.yaml
-        micromamba env create --name stenv --file ~/Downloads/stenv.yaml 
 
 This environment is unpinned, meaning it may take some time to resolve dependency versions. 
 Additionally, the resulting package versions may not have been tested for your platform.
@@ -42,6 +42,13 @@ some packages are not supported and / or deprecated, and some are deemed too nic
 
 To install a package in your local environment, you can use ``pip install`` while the environment is activated:
 
+.. tab:: micromamba
+
+    .. code-block:: shell
+
+        micromamba activate stenv
+        pip install <package_name>
+
 .. tab:: mamba
 
     .. code-block:: shell
@@ -54,13 +61,6 @@ To install a package in your local environment, you can use ``pip install`` whil
     .. code-block:: shell
 
         conda activate stenv
-        pip install <package_name>
-
-.. tab:: micromamba
-
-    .. code-block:: shell
-
-        micromamba activate stenv
         pip install <package_name>
 
 To request that a new package be added to ``stenv`` (:ref:`environment_yaml`) for all users, see :ref:`adding_a_package_to_stenv`.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -115,28 +115,26 @@ newest (highest-numbered) Python version available.
     Therefore, I recommend using a more descriptive name than ``stenv`` for your environment; for example, 
     use something like ``stenv-py3.11-2023.01.01`` (changed as needed to match the version you chose).
 
-Right-click (or control-click on macOS) on the link to the release file and choose ``Copy Link`` (or 
-``Copy Link Address``). Then, run the following command in a terminal, replacing ``<URL>`` with the URL you copied in the previous 
-step:
+Download the file corresponding to your platform and desired Python version, then run the following command 
+in a terminal using the file you downloaded (in this example ``stenv-Linux-py3.10-2023.02.16.yaml``):
 
 .. tab:: micromamba
 
     .. code-block:: shell
 
-        curl -L <URL> -o ~/Downloads/stenv.yaml
-        micromamba env create --name stenv --file ~/Downloads/stenv.yaml
+        micromamba env create --name stenv --file ~/Downloads/stenv-Linux-py3.10-2023.02.16.yaml
 
 .. tab:: mamba
 
     .. code-block:: shell
 
-        mamba env create --name stenv --file <URL>
+        mamba env create --name stenv --file ~/Downloads/stenv-Linux-py3.10-2023.02.16.yaml
 
 .. tab:: conda
 
     .. code-block:: shell
 
-        conda env create --name stenv --file <URL>
+        conda env create --name stenv --file ~/Downloads/stenv-Linux-py3.10-2023.02.16.yaml
 
 .. note::
     If the build does not succeed on your system, please refer to :ref:`build_fails`

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -41,6 +41,7 @@ For these reasons, I recommended you use ``micromamba``.
     .. code-block:: shell
 
         brew install micromamba
+        micromamba shell init
 
     You may also follow `these installation instructions <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html>`_.
     

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -181,9 +181,10 @@ Activating a Conda environment changes which Python interpreter and packages are
 .. code-block:: shell
 
     (stenv) $ python -c 'import jwst; print("ok")'
+    ok
 
 Every time you open a new terminal window, you will need to activate the environment before you can use 
-``stenv`` software.
+software included in ``stenv``.
 
 .. note::
     You can show installed packages available within a Conda environment with ``conda list``:

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -43,17 +43,23 @@ well as hundreds of useful tools, libraries, and utilities by default.
     Remember to run ``conda init`` when installing. This is required in order to set up your shell to 
     ``activate`` and ``deactivate`` environments.
 
+    .. tab:: mamba
+
+        .. code-block:: shell
+
+            mamba init
+
     .. tab:: conda
 
         .. code-block:: shell
 
             conda init
 
-    .. tab:: mamba
+    .. tab:: micromamba
 
         .. code-block:: shell
 
-            mamba init
+            micromamba init
 
 .. _choose_release:
 
@@ -89,40 +95,28 @@ newest (highest-numbered) Python version available.
     Therefore, I recommend using a more descriptive name than ``stenv`` for your environment; for example, 
     use something like ``stenv-py3.11-2023.01.01`` (changed as needed to match the version you chose).
 
-.. tab:: create environment from URL
+Right-click (or control-click on macOS) on the link to the release file and choose ``Copy Link`` (or 
+``Copy Link Address``). Then, run the following command in a terminal, replacing ``<URL>`` with the URL you copied in the previous 
+step:
 
-    Right-click (or control-click on macOS) on the link to the release file and choose ``Copy Link`` (or 
-    ``Copy Link Address``). Then, run the following command in a terminal, replacing ``<URL>`` with the URL you copied in the previous 
-    step:
+.. tab:: mamba
 
-    .. tab:: conda
+    .. code-block:: shell
 
-        .. code-block:: shell
+        mamba env create --name stenv --file <URL>
 
-            conda env create --name stenv --file <URL>
+.. tab:: conda
 
-    .. tab:: mamba
+    .. code-block:: shell
 
-        .. code-block:: shell
+        conda env create --name stenv --file <URL>
 
-            mamba env create --name stenv --file <URL>
+.. tab:: micromamba
 
-.. tab:: create environment from downloaded file
+    .. code-block:: shell
 
-    Download the release file you chose. Then, run the following command in a terminal, replacing 
-    ``~/Downloads/stenv-pyXX-YY.MM.DD.yaml`` with the path to the file you downloaded:
-
-    .. tab:: conda
-
-        .. code-block:: shell
-
-            conda env create --name stenv --file ~/Downloads/stenv-pyXX-YY.MM.DD.yaml
-
-    .. tab:: mamba
-
-        .. code-block:: shell
-
-            mamba env create --name stenv --file ~/Downloads/stenv-pyXX-YY.MM.DD.yaml
+        curl -L <URL> -o ~/Downloads/stenv.yaml
+        micromamba env create --name stenv --file ~/Downloads/stenv.yaml
 
 
 .. note::
@@ -146,17 +140,23 @@ In order to access the packages in ``stenv``, you must first ``activate`` the en
 .. important::
     If you chose another name when creating the environment, use that here instead.
 
+.. tab:: mamba
+
+    .. code-block:: shell
+
+        mamba activate stenv
+
 .. tab:: conda
 
     .. code-block:: shell
 
         conda activate stenv
 
-.. tab:: mamba
+.. tab:: micromamba
 
     .. code-block:: shell
 
-        mamba activate stenv
+        micromamba activate stenv
 
 Activating a Conda environment changes which Python interpreter and packages are in use for that session 
 (i.e. terminal window). Now, if you try to ``import jwst``:
@@ -171,20 +171,32 @@ Every time you open a new terminal window, you will need to activate the environ
 .. note::
     You can show installed packages available within a Conda environment with ``conda list``:
 
-    .. tab:: conda
-
-        .. code-block:: shell
-
-            conda list
-
     .. tab:: mamba
 
         .. code-block:: shell
 
             mamba list
 
+    .. tab:: conda
+
+        .. code-block:: shell
+
+            conda list
+
+    .. tab:: micromamba
+
+        .. code-block:: shell
+
+            micromamba list
+
 To ``deactivate`` an environment and return your shell to normal, close your terminal window or run 
 ``conda deactivate``:
+
+.. tab:: mamba
+
+    .. code-block:: shell
+
+        mamba deactivate
 
 .. tab:: conda
 
@@ -192,11 +204,11 @@ To ``deactivate`` an environment and return your shell to normal, close your ter
 
         conda deactivate
 
-.. tab:: mamba
+.. tab:: micromamba
 
     .. code-block:: shell
 
-        mamba deactivate
+        micromamba deactivate
 
 Deleting an environment
 =======================
@@ -206,15 +218,21 @@ To delete an environment with all of its packages, run ``conda env remove --name
 .. important::
     If you chose another name when creating the environment, use that here instead.
 
+.. tab:: mamba
+
+    .. code-block:: shell
+
+        mamba env remove --name stenv
+
 .. tab:: conda
 
     .. code-block:: shell
 
         conda env remove --name stenv
 
-.. tab:: mamba
+.. tab:: micromamba
 
     .. code-block:: shell
 
-        mamba env remove --name stenv
+        micromamba env remove --name stenv
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -20,46 +20,66 @@ Installation
 Install Conda
 -------------
 
-A Conda distribution provides the ``conda`` command, which lets you create, manage, and activate new 
-environments. Try running the ``conda`` command in your terminal. If you get ``conda: command not found`` 
-(or similar), you will need to install a conda distribution. If you already have a ``conda`` command in 
-your terminal, you can skip to the next step.
+A Conda distribution provides the ``micromamba`` / ``mamba`` / ``conda`` command, which lets you create, manage, and switch to 
+(activate) environments. Try running ``micromamba``, ``mamba``, or ``conda`` in your terminal. If you get ``command not found`` 
+(or similar), see below to install. 
 
-The easiest option is to install 
-`Miniconda <https://docs.conda.io/projects/miniconda/en/latest/miniconda-install.html>`_, which is 
-full-featured but installs a minimal set of default packages initially. We will install more packages later 
-on.
+``mamba`` is a rewrite of ``conda`` that is much faster at resolving dependencies with near-parity of commands. 
+``micromamba`` is ``mamba`` packaged into a single binary, which makes installation and maintenance much easier.
+For these reasons, I recommended you use ``micromamba``.
 
-Alternatives include `Miniforge <https://github.com/conda-forge/miniforge#miniforge3>`_, which includes the 
-``mamba`` command (a much faster drop-in replacement for ``conda`` with all the same functionality) and 
-`Anaconda <https://www.anaconda.com/distribution/>`_ which provides a full-featured base environment as 
-well as hundreds of useful tools, libraries, and utilities by default.
+.. tab:: micromamba
 
-.. note::
-    The below instructions will work for any of the distributions, though users with ``mamba`` installed 
-    will notice a speedup if they substitute ``mamba`` for ``conda`` where it appears in commands.
+    Run the following in your terminal to install ``micromamba``:
 
-.. important::
-    Remember to run ``conda init`` when installing. This is required in order to set up your shell to 
-    ``activate`` and ``deactivate`` environments.
+    .. code-block:: shell
 
-    .. tab:: mamba
+        "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
+
+    On macOS, you can alternatively install ``micromamba`` from `Homebrew <https://brew.sh/>`_:
+
+    .. code-block:: shell
+
+        brew install micromamba
+
+    You may also follow `these installation instructions <https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html>`_.
+    
+.. tab:: mamba
+
+    Follow 
+    `these instructions to install Miniforge <https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html>`_, 
+    which includes the ``mamba`` command in its base environment.
+
+    .. important::
+        Remember to run ``mamba init`` after installing. This is required in order to set up your shell to 
+        ``activate`` and ``deactivate`` environments.
 
         .. code-block:: shell
 
             mamba init
 
-    .. tab:: conda
+.. tab:: conda
+
+    .. caution::
+        The Anaconda organization has 
+        `updated their terms of service <https://legal.anaconda.com/policies/en/#:~:text=2.1%20Organizational%20Use.%C2%A0>`_ 
+        to indicate that any usage of their services requires a paid license, if used by an organization of 
+        more than 200 users. This includes pulling packages from the Anaconda ``defaults`` channels, as well as installing 
+        ``conda`` itself.
+
+        We recommend that you use ``mamba`` and pull packages from the ``conda-forge`` channel, instead of using ``conda`` 
+        and the ``defaults`` channels.
+
+    Follow `these instructions to install Miniconda <https://docs.conda.io/projects/miniconda/en/latest/miniconda-install.html>`_ 
+    which includes the ``conda`` command in its base environment.
+
+    .. important::
+        Remember to run ``conda init`` after installing. This is required in order to set up your shell to 
+        ``activate`` and ``deactivate`` environments.
 
         .. code-block:: shell
 
             conda init
-
-    .. tab:: micromamba
-
-        .. code-block:: shell
-
-            micromamba init
 
 .. _choose_release:
 
@@ -99,6 +119,13 @@ Right-click (or control-click on macOS) on the link to the release file and choo
 ``Copy Link Address``). Then, run the following command in a terminal, replacing ``<URL>`` with the URL you copied in the previous 
 step:
 
+.. tab:: micromamba
+
+    .. code-block:: shell
+
+        curl -L <URL> -o ~/Downloads/stenv.yaml
+        micromamba env create --name stenv --file ~/Downloads/stenv.yaml
+
 .. tab:: mamba
 
     .. code-block:: shell
@@ -110,14 +137,6 @@ step:
     .. code-block:: shell
 
         conda env create --name stenv --file <URL>
-
-.. tab:: micromamba
-
-    .. code-block:: shell
-
-        curl -L <URL> -o ~/Downloads/stenv.yaml
-        micromamba env create --name stenv --file ~/Downloads/stenv.yaml
-
 
 .. note::
     If the build does not succeed on your system, please refer to :ref:`build_fails`
@@ -140,6 +159,12 @@ In order to access the packages in ``stenv``, you must first ``activate`` the en
 .. important::
     If you chose another name when creating the environment, use that here instead.
 
+.. tab:: micromamba
+
+    .. code-block:: shell
+
+        micromamba activate stenv
+
 .. tab:: mamba
 
     .. code-block:: shell
@@ -151,12 +176,6 @@ In order to access the packages in ``stenv``, you must first ``activate`` the en
     .. code-block:: shell
 
         conda activate stenv
-
-.. tab:: micromamba
-
-    .. code-block:: shell
-
-        micromamba activate stenv
 
 Activating a Conda environment changes which Python interpreter and packages are in use for that session 
 (i.e. terminal window). Now, if you try to ``import jwst``:
@@ -171,6 +190,12 @@ Every time you open a new terminal window, you will need to activate the environ
 .. note::
     You can show installed packages available within a Conda environment with ``conda list``:
 
+    .. tab:: micromamba
+
+        .. code-block:: shell
+
+            micromamba list
+
     .. tab:: mamba
 
         .. code-block:: shell
@@ -183,14 +208,14 @@ Every time you open a new terminal window, you will need to activate the environ
 
             conda list
 
-    .. tab:: micromamba
-
-        .. code-block:: shell
-
-            micromamba list
-
 To ``deactivate`` an environment and return your shell to normal, close your terminal window or run 
 ``conda deactivate``:
+
+.. tab:: micromamba
+
+    .. code-block:: shell
+
+        micromamba deactivate
 
 .. tab:: mamba
 
@@ -204,12 +229,6 @@ To ``deactivate`` an environment and return your shell to normal, close your ter
 
         conda deactivate
 
-.. tab:: micromamba
-
-    .. code-block:: shell
-
-        micromamba deactivate
-
 Deleting an environment
 =======================
 
@@ -217,6 +236,12 @@ To delete an environment with all of its packages, run ``conda env remove --name
 
 .. important::
     If you chose another name when creating the environment, use that here instead.
+
+.. tab:: micromamba
+
+    .. code-block:: shell
+
+        micromamba env remove --name stenv
 
 .. tab:: mamba
 
@@ -229,10 +254,4 @@ To delete an environment with all of its packages, run ``conda env remove --name
     .. code-block:: shell
 
         conda env remove --name stenv
-
-.. tab:: micromamba
-
-    .. code-block:: shell
-
-        micromamba env remove --name stenv
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -36,7 +36,7 @@ For these reasons, I recommended you use ``micromamba``.
 
         "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
 
-    On macOS, you can alternatively install ``micromamba`` from `Homebrew <https://brew.sh/>`_:
+    On macOS, you can alternatively install ``micromamba`` using the `Homebrew package manager <https://brew.sh/>`_, if you have it installed:
 
     .. code-block:: shell
 


### PR DESCRIPTION
in response to the Anaconda ToS changes:
https://legal.anaconda.com/policies/en/#:~:text=2.1%20Organizational%20Use.%C2%A0
> 2.1 Organizational Use.  Your registration, download, use, installation, access, or enjoyment of all Anaconda Offerings on behalf of an organization that has two hundred (200) or more employees or contractors ("Organizational Use") requires a paid license. For sake of clarity, use by government entities and nonprofit entities with over 200 employees or contractors is considered Organizational Use.  Educational Entities will be exempt from the paid license requirement, provided that the use of the Anaconda Offering(s) is solely limited to being used for a curriculum-based course. Anaconda reserves the right to monitor the registration, download, use, installation, access, or enjoyment of the Anaconda Offerings to ensure it is part of a curriculum.  Utilizing Miniconda to pull package updates from the Anaconda Public Repository without a commercial license (if required by the conditions set forth in Section 2 of this Terms of Service) is considered a violation of the Terms of Service.