### PR TITLE
run tests for `drizzlepac`, `stistools`, and `stsynphot`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -215,6 +215,9 @@ jobs:
           ref: ${{ steps.package_version.outputs.version }}
           fetch-depth: 0
       - run: pip install pytest pytest-xdist ${{ matrix.test-dependencies }}
+      - if: matrix.package != 'hstcal'
+        run: pip install -e .
+        working-directory: ${{ matrix.package }}
       - run: pip list
       - if: matrix.pre_command != ''
         run: ${{ matrix.pre_command }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -132,7 +132,7 @@ jobs:
     needs: [ build, crds_contexts ]
     strategy:
       matrix:
-        package: [ hstcal, calcos ]
+        package: [ calcos, drizzlepac, hstcal, stistools, stsynphot ]
         # the macOS 13 runner is on Intel hardware
         runs-on: [ ubuntu-latest, macos-13, macos-latest ]
         python-version: [ '3.10', '3.11', '3.12' ]
@@ -144,13 +144,13 @@ jobs:
               pytest
               pytest-cov
             pytest-args: --slow
-          #- package: drizzlepac
-          #  repository: spacetelescope/drizzlepac
-          #  test-dependencies: >-
-          #      ci_watson
-          #      crds
-          #      pytest
-          #      pytest-remotedata
+          - package: drizzlepac
+            repository: spacetelescope/drizzlepac
+            test-dependencies: >-
+                ci_watson
+                crds
+                pytest
+                pytest-remotedata
           - package: hstcal
             repository: spacetelescope/hstcal
             test-dependencies: >-
@@ -159,13 +159,13 @@ jobs:
             pytest-args: --slow
             test-directory: tests
             crds-observatory: hst
-          #- package: stistools
-          #  repository: spacetelescope/stistools
-          #- package: stsynphot
-          #  repository: spacetelescope/stsynphot_refactor
-          #  test-dependencies: >-
-          #    pytest-astropy
-          #    ci-watson
+          - package: stistools
+            repository: spacetelescope/stistools
+          - package: stsynphot
+            repository: spacetelescope/stsynphot_refactor
+            test-dependencies: >-
+              pytest-astropy
+              ci-watson
         exclude:
           - runs-on: macos-13
             python-version: '3.10'


### PR DESCRIPTION
- [x] `drizzlepac`
  ```
  =========================== short test summary info ============================
  FAILED tests/hap/test_pipeline.py::TestSingleton::test_astrometric_singleton[iaaua1n4q] - TypeError: download_crds() takes 1 positional argument but 2 were given
  FAILED tests/hap/test_svm_ibyt50.py::test_svm_point_total_cat - NameError: name 'expected_point_sources' is not defined
  FAILED tests/hap/test_svm_ibyt50.py::test_svm_segment_total_cat - NameError: name 'expected_segment_sources' is not defined
  = 3 failed, 47 passed, 74 skipped, 2 xfailed, 2317 warnings in 810.85s (0:13:30) =
  ```
- [ ] `stistools`
  ```
  ImportError while loading conftest '/home/runner/work/stenv/stenv/stistools/tests/conftest.py'.
  tests/conftest.py:7: in <module>
      from astropy.tests.helper import enable_deprecations_as_exceptions
  E   ImportError: cannot import name 'enable_deprecations_as_exceptions' from 'astropy.tests.helper' (/home/runner/micromamba/envs/stenv-Linux-py3.12/lib/python3.12/site-  packages/astropy/tests/helper.py)
  ```
- [ ] `stsynphot `
  ```
  ImportError while loading conftest '/home/runner/work/stenv/stenv/stsynphot/conftest.py'.
  conftest.py:9: in <module>
      from stsynphot import __version__ as version
  stsynphot/__init__.py:17: in <module>
      from .spectrum import band, ebmvx, Vega  # noqa
  stsynphot/spectrum.py:622: in <module>
      load_vega(encoding='binary')
  stsynphot/spectrum.py:615: in load_vega
      warnings.warn(
  E   astropy.utils.exceptions.AstropyUserWarning: Failed to load Vega spectrum from /tmp/trds/calspec/alpha_lyr_stis_010.fits; Functionality involving Vega will be cripped:   FileNotFoundError(2, 'No such file or directory')
  ```