### PR TITLE
MNT: Use hash for Action workflow versions and update if needed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,8 +38,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     name: build (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})
     steps:
-      - uses: actions/checkout@v4
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
+      - uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822  # v1.9.0
         with:
           environment-name: stenv-${{ runner.os }}-py${{ matrix.python-version }}
           environment-file: environment.yaml
@@ -61,11 +61,11 @@ jobs:
           cat ${{ steps.output.outputs.filename }}
       - run: pip install pytest pytest-xdist
       - run: pytest -n auto tests/test_import.py
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
         with:
           name: ${{ steps.output.outputs.filename }}
           path: ${{ steps.output.outputs.filename }}
       - if: (github.event_name == 'release' && github.event.action == 'published')
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd  # 2.9.0
         with:
           file: ${{ steps.output.outputs.filename }}

--- a/.github/workflows/label_pull_request.yaml
+++ b/.github/workflows/label_pull_request.yaml
@@ -10,7 +10,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5.0.0
         if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,12 +76,12 @@ jobs:
           echo CRDS_CONTEXT=${{ matrix.crds-observatory == 'hst' && needs.crds_contexts.outputs.hst || matrix.crds-observatory == 'jwst' && needs.crds_contexts.outputs.jwst || matrix.crds-observatory == 'roman' && needs.crds_contexts.outputs.roman || '' }} >> $GITHUB_ENV
         shell: bash
       - if: env.CRDS_CONTEXT != ''
-        uses: actions/cache@v4
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9  # v4.0.2
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ matrix.package }}-${{ env.CRDS_CONTEXT }}
-      - uses: actions/checkout@v4
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
+      - uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822  # v1.9.0
         with:
           environment-name: stenv-${{ runner.os }}-py${{ matrix.python-version }}
           environment-file: environment.yaml
@@ -148,14 +148,14 @@ jobs:
           echo CRDS_CONTEXT=${{ matrix.crds-observatory == 'hst' && needs.crds_contexts.outputs.hst || matrix.crds-observatory == 'jwst' && needs.crds_contexts.outputs.jwst || matrix.crds-observatory == 'roman' && needs.crds_contexts.outputs.roman || '' }} >> $GITHUB_ENV
         shell: bash
       - if: env.CRDS_CONTEXT != ''
-        uses: actions/cache@v4
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9  # v4.0.2
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ matrix.package }}-${{ env.CRDS_CONTEXT }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
         with:
           path: stenv
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822  # v1.9.0
         with:
           environment-name: stenv-${{ runner.os }}-py${{ matrix.python-version }}
           environment-file: stenv/environment.yaml
@@ -170,7 +170,7 @@ jobs:
       - run: echo "version=$(pip list | awk '$1 == "${{ matrix.package }}" {print $2}')" >> $GITHUB_OUTPUT
         id: package_version
         # TODO: figure out a better way to use package version when checking out a Git ref
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
         with:
           path: ${{ matrix.package }}
           repository: ${{ matrix.repository }}
@@ -191,9 +191,9 @@ jobs:
       - run: pytest ${{ matrix.test-directory }} ${{ matrix.pytest-args }} -n auto --dist=loadscope
         working-directory: ${{ matrix.package }}
   crds_contexts:
-    uses: spacetelescope/crds/.github/workflows/contexts.yml@master
+    uses: spacetelescope/crds/.github/workflows/contexts.yml@d96060f99a7ca75969f6652b050243592f4ebaeb  # 12.0.0
   crds_test_cache:
-    uses: spacetelescope/crds/.github/workflows/cache.yml@master
+    uses: spacetelescope/crds/.github/workflows/cache.yml@d96060f99a7ca75969f6652b050243592f4ebaeb  # 12.0.0
   test_crds_with_data:
     needs: [ build, crds_test_cache ]
     strategy:
@@ -223,10 +223,10 @@ jobs:
       CRDS_TESTING_CACHE: /tmp/crds-cache-test
       CRDS_SERVER_URL: https://hst-crds.stsci.edu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
         with:
           path: stenv
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822  # v1.9.0
         with:
           environment-name: stenv-${{ runner.os }}-py${{ matrix.python-version }}
           environment-file: stenv/environment.yaml
@@ -244,7 +244,7 @@ jobs:
       - run: echo "version=$(pip list | awk '$1 == "${{ matrix.package }}" {print $2}')" >> $GITHUB_OUTPUT
         id: package_version
         # TODO: figure out a better way to use package version when checking out a Git ref
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
         with:
           path: ${{ matrix.package }}
           repository: ${{ matrix.repository }}
@@ -252,7 +252,7 @@ jobs:
           fetch-depth: 0
       - run: pip uninstall --yes crds && ./install && pip install .[submission,test,docs,synphot]
         working-directory: ${{ matrix.package }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9  # v4.0.2
         with:
           path: |
             ${{ needs.crds_test_cache.outputs.path }}
@@ -299,14 +299,14 @@ jobs:
           echo CRDS_CONTEXT=${{ matrix.crds-observatory == 'hst' && needs.crds_contexts.outputs.hst || matrix.crds-observatory == 'jwst' && needs.crds_contexts.outputs.jwst || matrix.crds-observatory == 'roman' && needs.crds_contexts.outputs.roman || '' }} >> $GITHUB_ENV
         shell: bash
       - if: env.CRDS_CONTEXT != ''
-        uses: actions/cache@v4
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9  # v4.0.2
         with:
           path: ${{ env.CRDS_PATH }}
           key: crds-${{ matrix.package }}-${{ env.CRDS_CONTEXT }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0
         with:
           lfs: true
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822  # v1.9.0
         with:
           environment-name: stenv-${{ runner.os }}-py${{ matrix.python-version }}
           environment-file: environment.yaml
@@ -320,7 +320,7 @@ jobs:
           generate-run-shell: true
       - run: pip install pytest pytest-xdist ${{ matrix.test-dependencies }}
       - run: pip list
-      - uses: actions/cache@v4
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9  # v4.0.2
         with:
           path: tests/data/
           key: data-${{ hashFiles('tests/data/*') }}


### PR DESCRIPTION
As recommended by https://scientific-python.org/specs/spec-0008/#pin-github-actions-release-workflows-to-their-full-release-commit-shas , this PR changes your Actions workflow version pins to hashes, and updates to latest release hashes (at the time of writing) if needed.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

[:ghost:](https://github.com/pllim/playpen/issues/60)