### PR TITLE
BLD: Remove macos-13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         # the macOS 13 runner is on Intel hardware
-        runs-on: [ ubuntu-latest, macos-13, macos-latest ]
+        runs-on: [ ubuntu-latest, macos-latest ]
         python-version: [ '3.11', '3.12', '3.13' ]
     runs-on: ${{ matrix.runs-on }}
     name: build (Python ${{ matrix.python-version }}, ${{ matrix.runs-on }})


### PR DESCRIPTION
https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down